### PR TITLE
Add startup and recovery frames to command input overlay

### DIFF
--- a/GUI_CommandInputOverlay.py
+++ b/GUI_CommandInputOverlay.py
@@ -72,7 +72,7 @@ class GUI_CommandInputOverlay(GUI_Overlay.Overlay):
         if self.launcher.gameState.stateLog[-1].is_player_player_one:
             input = self.launcher.gameState.stateLog[-1].bot.GetInputState()
             cancelable = self.launcher.gameState.stateLog[-1].bot.is_cancelable
-            bufferable1 = self.launcher.gameState.stateLog[-1].bot.is_bufferable
+            bufferable = self.launcher.gameState.stateLog[-1].bot.is_bufferable
             parry1 = self.launcher.gameState.stateLog[-1].bot.is_parry_1
             parry2 = self.launcher.gameState.stateLog[-1].bot.is_parry_2
             starting = self.launcher.gameState.stateLog[-1].bot.is_starting
@@ -80,7 +80,7 @@ class GUI_CommandInputOverlay(GUI_Overlay.Overlay):
         else:
             input = self.launcher.gameState.stateLog[-1].opp.GetInputState()
             cancelable = self.launcher.gameState.stateLog[-1].opp.is_cancelable
-            bufferable1 = self.launcher.gameState.stateLog[-1].opp.is_bufferable
+            bufferable = self.launcher.gameState.stateLog[-1].opp.is_bufferable
             parry1 = self.launcher.gameState.stateLog[-1].opp.is_parry_1
             parry2 = self.launcher.gameState.stateLog[-1].opp.is_parry_2
             starting = self.launcher.gameState.stateLog[-1].opp.is_starting
@@ -88,9 +88,9 @@ class GUI_CommandInputOverlay(GUI_Overlay.Overlay):
         frame_count = self.launcher.gameState.stateLog[-1].frame_count
         #print(input)
         self.update_input(input, self.color_from_cancel_booleans(
-            cancelable, bufferable1, parry1, parry2, starting, recovering))
+            cancelable, bufferable, parry1, parry2, starting, recovering))
 
-    def color_from_cancel_booleans(self, cancelable, bufferable1, parry1, parry2, starting, recovering):
+    def color_from_cancel_booleans(self, cancelable, bufferable, parry1, parry2, starting, recovering):
         
         # default
         fill_color = 'snow'
@@ -103,12 +103,12 @@ class GUI_CommandInputOverlay(GUI_Overlay.Overlay):
             fill_color = 'orange'
         elif parry2:
             fill_color = 'yellow'
-        elif bufferable1:
+        elif bufferable:
             fill_color = 'MediumOrchid1'
         elif cancelable:
             fill_color = 'SteelBlue1'
 
-            
+
         return fill_color
 
     def update_input(self, input, cancel_color):

--- a/GUI_CommandInputOverlay.py
+++ b/GUI_CommandInputOverlay.py
@@ -66,36 +66,49 @@ class GUI_CommandInputOverlay(GUI_Overlay.Overlay):
         self.stored_inputs = []
         self.stored_cancels = []
 
-
+    # Update state to reflect game state one frame ago
     def update_state(self):
         GUI_Overlay.Overlay.update_state(self)
         if self.launcher.gameState.stateLog[-1].is_player_player_one:
             input = self.launcher.gameState.stateLog[-1].bot.GetInputState()
             cancelable = self.launcher.gameState.stateLog[-1].bot.is_cancelable
-            bufferable = self.launcher.gameState.stateLog[-1].bot.is_bufferable
+            bufferable1 = self.launcher.gameState.stateLog[-1].bot.is_bufferable
             parry1 = self.launcher.gameState.stateLog[-1].bot.is_parry_1
             parry2 = self.launcher.gameState.stateLog[-1].bot.is_parry_2
+            starting = self.launcher.gameState.stateLog[-1].bot.is_starting
+            recovering = self.launcher.gameState.stateLog[-1].bot.is_recovering
         else:
             input = self.launcher.gameState.stateLog[-1].opp.GetInputState()
             cancelable = self.launcher.gameState.stateLog[-1].opp.is_cancelable
-            bufferable = self.launcher.gameState.stateLog[-1].opp.is_bufferable
+            bufferable1 = self.launcher.gameState.stateLog[-1].opp.is_bufferable
             parry1 = self.launcher.gameState.stateLog[-1].opp.is_parry_1
             parry2 = self.launcher.gameState.stateLog[-1].opp.is_parry_2
+            starting = self.launcher.gameState.stateLog[-1].opp.is_starting
+            recovering = self.launcher.gameState.stateLog[-1].opp.is_recovering
         frame_count = self.launcher.gameState.stateLog[-1].frame_count
         #print(input)
-        self.update_input(input, self.color_from_cancel_booleans(cancelable, bufferable, parry1, parry2))
+        self.update_input(input, self.color_from_cancel_booleans(
+            cancelable, bufferable1, parry1, parry2, starting, recovering))
 
-    def color_from_cancel_booleans(self, cancelable, bufferable, parry1, parry2):
+    def color_from_cancel_booleans(self, cancelable, bufferable1, parry1, parry2, starting, recovering):
+        
+        # default
+        fill_color = 'snow'
+        if starting:
+            fill_color = 'green4'
+        elif recovering:
+            fill_color = 'red4'
+        
         if parry1:
             fill_color = 'orange'
         elif parry2:
             fill_color = 'yellow'
-        elif bufferable:
+        elif bufferable1:
             fill_color = 'MediumOrchid1'
         elif cancelable:
             fill_color = 'SteelBlue1'
-        else:
-            fill_color = 'firebrick1'
+
+            
         return fill_color
 
     def update_input(self, input, cancel_color):

--- a/TekkenGameState.py
+++ b/TekkenGameState.py
@@ -339,11 +339,22 @@ class BotSnapshot:
         self.power_crush_flag = d['PlayerDataAddress.power_crush'] > 0
 
         cancel_window_bitmask = d['PlayerDataAddress.cancel_window']
+        recovery_window_bitmask = d['PlayerDataAddress.recovery']
 
+        # TODO FLAG CLEANUP LATER
         self.is_cancelable = (CancelStatesBitmask.CANCELABLE.value & cancel_window_bitmask) == CancelStatesBitmask.CANCELABLE.value
         self.is_bufferable = (CancelStatesBitmask.BUFFERABLE.value & cancel_window_bitmask) == CancelStatesBitmask.BUFFERABLE.value
         self.is_parry_1 = (CancelStatesBitmask.PARRYABLE_1.value & cancel_window_bitmask) == CancelStatesBitmask.PARRYABLE_1.value
         self.is_parry_2 = (CancelStatesBitmask.PARRYABLE_2.value & cancel_window_bitmask) == CancelStatesBitmask.PARRYABLE_2.value
+        
+        self.is_recovering = (ComplexMoveStates.RECOVERING.value & recovery_window_bitmask) == ComplexMoveStates.RECOVERING.value
+        
+        self.is_starting = False
+        # Check is player is in startup
+        if self.startup > 0:
+            self.is_starting = (self.move_timer <= self.startup)
+        else:
+            self.is_starting = False
 
         self.throw_tech = ThrowTechs(d['PlayerDataAddress.throw_tech'])
 

--- a/TekkenGameState.py
+++ b/TekkenGameState.py
@@ -341,7 +341,6 @@ class BotSnapshot:
         cancel_window_bitmask = d['PlayerDataAddress.cancel_window']
         recovery_window_bitmask = d['PlayerDataAddress.recovery']
 
-        # TODO FLAG CLEANUP LATER
         self.is_cancelable = (CancelStatesBitmask.CANCELABLE.value & cancel_window_bitmask) == CancelStatesBitmask.CANCELABLE.value
         self.is_bufferable = (CancelStatesBitmask.BUFFERABLE.value & cancel_window_bitmask) == CancelStatesBitmask.BUFFERABLE.value
         self.is_parry_1 = (CancelStatesBitmask.PARRYABLE_1.value & cancel_window_bitmask) == CancelStatesBitmask.PARRYABLE_1.value


### PR DESCRIPTION
This update also changes some on the coloring. Old firebrick red was changed to white. Green is now used for startup frames and red for recovery frames.